### PR TITLE
Remove deprecated quoted type constraints

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -28,13 +28,13 @@ variable "anomaly_period" {
 }
 
 variable "actions_alarm" {
-  type        = "list"
+  type        = list
   default     = []
   description = "A list of actions to take when alarms are triggered. Will likely be an SNS topic for event distribution."
 }
 
 variable "actions_ok" {
-  type        = "list"
+  type        = list
   default     = []
   description = "A list of actions to take when alarms are cleared. Will likely be an SNS topic for event distribution."
 }


### PR DESCRIPTION
Removing deprecated double quotes from list type variables.

```
Warning: Quoted type constraints are deprecated

  on .terraform/modules/aws-shared-rds-alarms/terraform-aws-rds-alarms-1.0.1/variables.tf line 31, in variable "actions_alarm":
  31:   type        = "list"

Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "list" and write
list(string) instead to explicitly indicate that the list elements are
strings.