### PR TITLE
update for environment enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 // CPU Utilization
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
+  count               = var.environment_enabled? "1":"0"
   alarm_name          = "${var.prefix}rds-${var.db_instance_id}-highCPUUtilization"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_period
@@ -40,6 +41,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
 
 // Disk Utilization
 resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
+  count               = var.environment_enabled? "1":"0"
   alarm_name          = "${var.prefix}rds-${var.db_instance_id}-highDiskQueueDepth"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_period
@@ -59,6 +61,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_queue_depth_too_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "disk_free_storage_space_too_low" {
+  count               = var.environment_enabled? "1":"0"
   alarm_name          = "${var.prefix}rds-${var.db_instance_id}-lowFreeStorageSpace"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_period
@@ -78,6 +81,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_free_storage_space_too_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "disk_burst_balance_too_low" {
+  count               = var.environment_enabled? "1":"0"
   alarm_name          = "${var.prefix}rds-${var.db_instance_id}-lowEBSBurstBalance"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_period
@@ -98,6 +102,7 @@ resource "aws_cloudwatch_metric_alarm" "disk_burst_balance_too_low" {
 
 // Memory Utilization
 resource "aws_cloudwatch_metric_alarm" "memory_freeable_too_low" {
+  count               = var.environment_enabled? "1":"0"
   alarm_name          = "${var.prefix}rds-${var.db_instance_id}-lowFreeableMemory"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_period
@@ -117,6 +122,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_freeable_too_low" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_swap_usage_too_high" {
+  count               = var.environment_enabled? "1":"0"
   alarm_name          = "${var.prefix}rds-${var.db_instance_id}-highSwapUsage"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = var.evaluation_period
@@ -137,6 +143,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_swap_usage_too_high" {
 
 // Connection Count
 resource "aws_cloudwatch_metric_alarm" "connection_count_anomalous" {
+  count               = var.environment_enabled? "1":"0"
   alarm_name          = "${var.prefix}rds-${var.db_instance_id}-anomalousConnectionCount"
   comparison_operator = "GreaterThanUpperThreshold"
   evaluation_periods  = var.evaluation_period

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
-  count               = length(regexall("(t2|t3)", var.db_instance_class)) && environment_enabled> 0 ? "1" : "0"
+  count               = length(regexall("(t2|t3)", var.db_instance_class)) && var.environment_enabled> 0 ? "1" : "0"
   alarm_name          = "${var.prefix}rds-${var.db_instance_id}-lowCPUCreditBalance"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_period

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_credit_balance_too_low" {
-  count               = length(regexall("(t2|t3)", var.db_instance_class)) > 0 ? "1" : "0"
+  count               = length(regexall("(t2|t3)", var.db_instance_class)) && environment_enabled> 0 ? "1" : "0"
   alarm_name          = "${var.prefix}rds-${var.db_instance_id}-lowCPUCreditBalance"
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = var.evaluation_period

--- a/variables.tf
+++ b/variables.tf
@@ -2,7 +2,10 @@ variable "db_instance_id" {
   type        = string
   description = "RDS Instance ID"
 }
-
+variable "environment_enabled"{
+  type		=bool
+  description   ="A true/false for whether the alarms are created in the desired environment"
+}
 variable "prefix" {
   type        = string
   default     = ""


### PR DESCRIPTION
The resources did not have a count check with them. The issue faced was that the alarms were being created in all environments, however, we would want the alarms to be created only in the selected environments, for which the value of enabled be true. So here I have introduced a 'environment_enabled' variable which takes a true/false value of the environment, and if the environment is true (that is the desired environment we want to create in) the only the alarms would be created.
Any suggestions/feedback on this would be helpful!