### PR TITLE
Early warning sytem for postgres' transaction ID wraparound

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Alarms Always Created (default values can be overridden):
 If the instance type is a T-Series instance type (automatically determind), the following alarms are also created:
 - CPU Credit Balance below 100
 
+If the database engine is any of postgres type (configured with var.engine), then the following alarms are also created:
+- Maximum used transaction IDs over 1,000,000,000
+
 **Estimated Operating Cost**: $ 1.00 / month
 
 - $ 0.10 / month for Metric Alarms (7x)
@@ -60,6 +63,7 @@ module "aws-rds-alarms" {
 | anomaly\_period | The number of seconds that make each evaluation period for anomaly detection. | `string` | `"600"` | no |
 | anomaly_band_width | The width of the anomaly band detection.  Higher numbers means less sensitive | `string` | `"2"` | no |
 | db\_instance\_id | RDS Instance ID | `string` | n/a | yes |
+| engine | The RDS engine being used. Used for database engine specific alarms | `string` | `""` | no |
 | evaluation\_period | The evaluation period over which to use when triggering alarms. | `string` | `"5"` | no |
 | prefix | Alarm Name Prefix | `string` | `""` | no |
 | statistic\_period | The number of seconds that make each statistic period. | `string` | `"60"` | no |
@@ -70,6 +74,7 @@ module "aws-rds-alarms" {
 | disk_queue_depth_too_high_threshold | Alarm threshold for the 'highDiskQueueDepth' alarm | `string` | `"64"` | no |
 | disk_free_storage_space_too_low_threshold | Alarm threshold for the 'lowFreeStorageSpace' alarm (in bytes) | `string` | `"10000000000"` | no |
 | disk_burst_balance_too_low_threshold | Alarm threshold for the 'lowEBSBurstBalance' alarm | `string` | `"100"` | no |
+| maximum_used_transaction_ids_too_high_threshold | Alarm threshold for the 'maximumUsedTransactionIDs' alarm | `string` | `"1000000000"` | no |
 | memory_freeable_too_low_threshold | Alarm threshold for the 'lowFreeableMemory' alarm (in bytes) | `string` | `"256000000"` | no |
 | memory_swap_usage_too_high_threshold | Alarm threshold for the 'highSwapUsage' alarm (in bytes) | `string` | `"256000000"` | no |
 
@@ -85,3 +90,4 @@ module "aws-rds-alarms" {
 | alarm\_disk\_queue\_depth\_too\_high | The CloudWatch Metric Alarm resource block for high Disk Queue Depth |
 | alarm\_memory\_freeable\_too\_low | The CloudWatch Metric Alarm resource block for low Freeable Memory |
 | alarm\_memory\_swap\_usage\_too\_high | The CloudWatch Metric Alarm resource block for high Memory Swap Usage |
+| alarm_maximum_used_transaction_ids_too_high | The CloudWatch Metric Alarm resource block for postgres' Transaction ID Wraparound |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If the instance type is a T-Series instance type (automatically determind), the 
 - CPU Credit Balance below 100
 
 If the database engine is any of postgres type (configured with var.engine), then the following alarms are also created:
-- Maximum used transaction IDs over 1,000,000,000
+- Maximum used transaction IDs over 1,000,000,000 [[reference](https://aws.amazon.com/blogs/database/implement-an-early-warning-system-for-transaction-id-wraparound-in-amazon-rds-for-postgresql/)]
 
 **Estimated Operating Cost**: $ 1.00 / month
 

--- a/main.tf
+++ b/main.tf
@@ -170,3 +170,19 @@ resource "aws_cloudwatch_metric_alarm" "connection_count_anomalous" {
   tags = var.tags
 }
 
+// [postgres, aurora-postgres] Early Warning System for Transaction ID Wraparound
+// more info - https://aws.amazon.com/blogs/database/implement-an-early-warning-system-for-transaction-id-wraparound-in-amazon-rds-for-postgresql/
+resource "aws_cloudwatch_metric_alarm" "maximum_used_transaction_ids_too_high" {
+  count               = contains(["aurora-postgresql", "postgres"], var.engine) ? 1 : 0
+  alarm_name          = "${var.prefix}rds-${var.db_instance_id}-maximumUsedTransactionIDs"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.evaluation_period
+  metric_name         = "MaximumUsedTransactionIDs"
+  namespace           = "AWS/RDS"
+  period              = var.statistic_period
+  statistic           = "Average"
+  threshold           = var.maximum_used_transaction_ids_too_high_threshold
+  alarm_description   = "Nearing a possible critical transaction ID wraparound."
+  alarm_actions       = var.actions_alarm
+  ok_actions          = var.actions_ok
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,8 @@ output "alarm_connection_count_anomalous" {
   value       = aws_cloudwatch_metric_alarm.connection_count_anomalous
   description = "The CloudWatch Metric Alarm resource block for anomalous Connection Count"
 }
+
+output "alarm_maximum_used_transaction_ids_too_high" {
+  value       = aws_cloudwatch_metric_alarm.maximum_used_transaction_ids_too_high
+  description = "The CloudWatch Metric Alarm resource block for postgres' Transaction ID Wraparound"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -97,3 +97,15 @@ variable "db_instance_class" {
   type      = string
   description = "The rds instance class, e.g. db.t3.medium"
 }
+
+variable "engine" {
+  type = string
+  description = "The RDS engine being used. Used for postgres or mysql specific alarms"
+  default = ""
+}
+
+variable "maximum_used_transaction_ids_too_high_threshold" {
+  type        = string
+  default     = "1000000000" // 1 billion. Half of total.
+  description = "Alarm threshold for the 'maximumUsedTransactionIDs' alarm"
+}


### PR DESCRIPTION
Based on [this blog post from AWS](https://aws.amazon.com/blogs/database/implement-an-early-warning-system-for-transaction-id-wraparound-in-amazon-rds-for-postgresql/), it implements a warning system to avoid transaction ID wraparound.

If this alarm is triggered, you should check your AUTOVACUUM progress. More info about this in AWS blog "[Understanding autovacuum in Amazon RDS for PostgreSQL environments](https://aws.amazon.com/blogs/database/understanding-autovacuum-in-amazon-rds-for-postgresql-environments/)"

New resources:
- `aws_cloudwatch_metric_alarm.maximum_used_transaction_ids_too_high`

New inputs:
- `var.engine` - by default it is set to an empty string. If that is configured to be either `postgres` or `aurora-postgresql` (same values that are used for [aws_db_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#engine)), then this new alarm is created.
- `var.maximum_used_transaction_ids_too_high_threshold` - set to 1,000,000,000 (1 billion), as recommended by AWS blog post mentioned above.

New outputs:
- `alarm_maximum_used_transaction_ids_too_high`

All resources, inputs and outputs are following the same naming and style convention as existing code. Only real difference is the conditional creation in case it is a postgres engine.

Tested and already in daily use in prod. Backwards compatible, does not affect existing setups.

