### PR TITLE
Feature: Making flag to disable noisy alarm for Connection Anomaly detection

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -137,6 +137,7 @@ resource "aws_cloudwatch_metric_alarm" "memory_swap_usage_too_high" {
 
 // Connection Count
 resource "aws_cloudwatch_metric_alarm" "connection_count_anomalous" {
+  count               = var.create_anomaly_alarm ? 1 : 0
   alarm_name          = "${var.prefix}rds-${var.db_instance_id}-anomalousConnectionCount"
   comparison_operator = "GreaterThanUpperThreshold"
   evaluation_periods  = var.evaluation_period

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,6 +34,6 @@ output "alarm_memory_swap_usage_too_high" {
 }
 
 output "alarm_connection_count_anomalous" {
-  value       = aws_cloudwatch_metric_alarm.connection_count_anomalous
+  value       = aws_cloudwatch_metric_alarm.connection_count_anomalous.*
   description = "The CloudWatch Metric Alarm resource block for anomalous Connection Count"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "statistic_period" {
   description = "The number of seconds that make each statistic period."
 }
 
+variable "create_anomaly_alarm" {
+  type        = bool
+  default     = true
+  description = "Whether or not to create the fairly noisy anomaly alarm.  Default is to create it (for backwards compatible support)"
+}
+
 variable "anomaly_period" {
   type        = string
   default     = "600"


### PR DESCRIPTION
Self-explanatory from subject above.  Default is to do exactly like it did before, to create this alarm, but allowing it to be disabled is really helpful on noisy and inconsistent environments (like dev/staging/testing envs).