### PR TITLE
Update main.tf to get rid of warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
 // CPU Utilization
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
   count               = var.create_high_cpu_alarm ? 1 : 0


### PR DESCRIPTION
Update main.tf to get rid of warning:

```
│ Warning: Reference to undefined provider
│
│   on main.tf line 49, in module "aws-rds-alarms-statsdevapps":
│   49:     aws = aws.euwest1
│
│ There is no explicit declaration for local provider name "aws" in module.aws-rds-alarms-statsdevapps, so Terraform is assuming you mean to pass a configuration for "hashicorp/aws".
│
│ If you also control the child module, add a required_providers entry named "aws" with the source address "hashicorp/aws".
```