### PR TITLE
Fix DBInstanceIdentifier value in read & write IOPS alarms.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -218,7 +218,7 @@ resource "aws_cloudwatch_metric_alarm" "read_iops_too_high" {
   ok_actions          = var.actions_ok
 
   dimensions = {
-    DBInstanceIdentifier = "${var.db_instance_id}-read-iops-too-high"
+    DBInstanceIdentifier = var.db_instance_id
   }
 }
 
@@ -237,6 +237,6 @@ resource "aws_cloudwatch_metric_alarm" "write_iops_too_high" {
   ok_actions          = var.actions_ok
 
   dimensions = {
-    DBInstanceIdentifier = "${var.prefix}rds-${var.db_instance_id}-write-iops-too-high"
+    DBInstanceIdentifier = var.db_instance_id
   }
 }


### PR DESCRIPTION
Thanks for creating this module!

I noticed that the IOPS alarms were showing up as `Insufficient Data` caused by the `DBInstanceIdentifier` value being incorrect for these alarms.